### PR TITLE
Rename Grakn to TypeDB

### DIFF
--- a/cluster/cluster_database.proto
+++ b/cluster/cluster_database.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,10 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "ClusterDatabaseProto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message ClusterDatabaseManager {
 

--- a/cluster/cluster_server.proto
+++ b/cluster/cluster_server.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,10 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "ClusterServerProto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message ServerManager {
     message All {

--- a/cluster/cluster_service.proto
+++ b/cluster/cluster_service.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,16 +17,16 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "ClusterServiceProto";
 option java_generic_services = true;
 
 import "cluster/cluster_server.proto";
 import "cluster/cluster_database.proto";
 
-package grakn.protocol;
+package typedb.protocol;
 
-service GraknCluster {
+service TypeDBCluster {
 
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);
     rpc databases_get (ClusterDatabaseManager.Get.Req) returns (ClusterDatabaseManager.Get.Res);

--- a/common/answer.proto
+++ b/common/answer.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,12 +17,12 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "AnswerProto";
 
 import "common/concept.proto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message ConceptMap {
     map<string, Concept> map = 1;

--- a/common/concept.proto
+++ b/common/concept.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,10 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "ConceptProto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message ConceptManager {
 

--- a/common/logic.proto
+++ b/common/logic.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,13 +17,13 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "LogicProto";
 
 import "common/answer.proto";
 
 
-package grakn.protocol;
+package typedb.protocol;
 
 message LogicManager {
 

--- a/common/options.proto
+++ b/common/options.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,10 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "OptionsProto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 // TODO: Replace 'oneof' with 'optional' when upgraded to Protobuf 3.13 everywhere
 // https://github.com/protocolbuffers/protobuf/issues/1606#issuecomment-618687169

--- a/common/query.proto
+++ b/common/query.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,14 +17,14 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "QueryProto";
 
 import "common/answer.proto";
 import "common/logic.proto";
 import "common/options.proto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message QueryManager {
 

--- a/common/session.proto
+++ b/common/session.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,12 +17,12 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "SessionProto";
 
 import "common/options.proto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message Session {
 

--- a/common/transaction.proto
+++ b/common/transaction.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,7 +17,7 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "TransactionProto";
 
 import "common/concept.proto";
@@ -25,7 +25,7 @@ import "common/logic.proto";
 import "common/options.proto";
 import "common/query.proto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message Transaction {
 
@@ -52,7 +52,7 @@ message Transaction {
             ConceptManager.Req concept_manager_req = 8;
             LogicManager.Req logic_manager_req = 9;
             Rule.Req rule_req = 10;
-            grakn.protocol.Type.Req type_req = 11;
+            typedb.protocol.Type.Req type_req = 11;
             Thing.Req thing_req = 12;
         }
     }
@@ -67,7 +67,7 @@ message Transaction {
             ConceptManager.Res concept_manager_res = 6;
             LogicManager.Res logic_manager_res = 7;
             Rule.Res rule_res = 8;
-            grakn.protocol.Type.Res type_res = 9;
+            typedb.protocol.Type.Res type_res = 9;
             Thing.Res thing_res = 10;
         }
     }
@@ -78,7 +78,7 @@ message Transaction {
             Stream.ResPart stream_res_part = 2;
             QueryManager.ResPart query_manager_res_part = 3;
             LogicManager.ResPart logic_manager_res_part = 4;
-            grakn.protocol.Type.ResPart type_res_part = 5;
+            typedb.protocol.Type.ResPart type_res_part = 5;
             Thing.ResPart thing_res_part = 6;
         }
     }

--- a/core/core_database.proto
+++ b/core/core_database.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,10 +17,10 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "CoreDatabaseProto";
 
-package grakn.protocol;
+package typedb.protocol;
 
 message CoreDatabaseManager {
 

--- a/core/core_service.proto
+++ b/core/core_service.proto
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 Grakn Labs
+// Copyright (C) 2021 TypeDB Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -17,7 +17,7 @@
 
 syntax = "proto3";
 
-option java_package = "grakn.protocol";
+option java_package = "typedb.protocol";
 option java_outer_classname = "CoreServiceProto";
 option java_generic_services = true;
 
@@ -25,22 +25,10 @@ import "core/core_database.proto";
 import "common/session.proto";
 import "common/transaction.proto";
 
-package grakn.protocol;
+package typedb.protocol;
 
-service GraknCore {
+service TypeDBCore {
 
-    // Database Manager API
-    rpc databases_contains (CoreDatabaseManager.Contains.Req) returns (CoreDatabaseManager.Contains.Res);
-    rpc databases_create (CoreDatabaseManager.Create.Req) returns (CoreDatabaseManager.Create.Res);
-    rpc databases_all (CoreDatabaseManager.All.Req) returns (CoreDatabaseManager.All.Res);
-
-    // Database API
-    rpc database_schema (CoreDatabase.Schema.Req) returns (CoreDatabase.Schema.Res);
-    rpc database_delete (CoreDatabase.Delete.Req) returns (CoreDatabase.Delete.Res);
-
-    // Session API
-    rpc session_open (Session.Open.Req) returns (Session.Open.Res);
-    rpc session_close (Session.Close.Req) returns (Session.Close.Res);
     // Checks with the server that the session is still alive, and informs it that it should be kept alive.
     rpc session_pulse (Session.Pulse.Req) returns (Session.Pulse.Res);
 


### PR DESCRIPTION
## What is the goal of this PR?

We renamed Grakn to TypeDB. All occurrences of "Grakn" have been replaced with "TypeDB".

## What are the changes implemented in this PR?

Rename Grakn to TypeDB