### PR TITLE
Fix a README to only contain ASCII symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A protocol for implementing a TypeDB client driver, in many popular programming 
 
 ## Licensing
 
-The TypeDB protocol is distributed under the terms GNU Affero General Public License v3.0 (“AGPL 3.0”) as published by the Free Software Foundation, but with the following special exception.
+The TypeDB protocol is distributed under the terms GNU Affero General Public License v3.0 ("AGPL 3.0") as published by the Free Software Foundation, but with the following special exception.
 
 Exception to AGPL 3.0: Any driver or client library (in each case) that implements the TypeDB protocol, and that is used to communicate or interact (in each case) with a database created or managed or accessed (in each case) using a version of the TypeDB software that is made available by or on behalf of Vaticle Limited (UK Company Number 08766237) or any successor entity (but excluding any forked version of that software), may be distributed under one of the following licences:
 
@@ -14,6 +14,6 @@ Exception to AGPL 3.0: Any driver or client library (in each case) that implemen
 - The MIT License: https://opensource.org/licenses/MIT
 - The BSD License (2-Clause): https://opensource.org/licenses/BSD-2-Clause
 
-As used above “successor entity” means any entity then owning copyrights in the TypeDB software that were previously owned by Vaticle Limited.
+As used above "successor entity" means any entity then owning copyrights in the TypeDB software that were previously owned by Vaticle Limited.
 
 If you make any change to, or contribute to, (in each case) the TypeDB protocol, then this exception will apply to any driver or client library that uses or implements that change/contribution.


### PR DESCRIPTION
## What is the goal of this PR?

Unblock deployment to PyPI

## What are the changes implemented in this PR?

Replace Unicode quotes in `README` with ASCII quotes