### PR TITLE
Added user management protocol for TypeDB Cluster

### DIFF
--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -24,6 +24,7 @@ proto_library(
     srcs = [":cluster_service.proto"],
     deps = [
         ":server-proto",
+        ":user-proto",
         ":database-proto"
     ],
 )
@@ -31,6 +32,11 @@ proto_library(
 proto_library(
     name = "server-proto",
     srcs = [":cluster_server.proto"],
+)
+
+proto_library(
+    name = "user-proto",
+    srcs = [":cluster_user.proto"],
 )
 
 proto_library(

--- a/cluster/cluster_service.proto
+++ b/cluster/cluster_service.proto
@@ -28,10 +28,18 @@ import "cluster/cluster_database.proto";
 package typedb.protocol;
 
 service TypeDBCluster {
+    // Server Manager API
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);
+
+    // User Manager API
     rpc users_contains (ClusterUserManager.Contains.Req) returns (ClusterUserManager.Contains.Res);
     rpc users_create (ClusterUserManager.Create.Req) returns (ClusterUserManager.Create.Res);
     rpc users_all (ClusterUserManager.All.Req) returns (ClusterUserManager.All.Res);
+
+    // User API
+    rpc users_delete (ClusterUser.Delete.Req) returns (ClusterUser.Delete.Res);
+
+    // Database Manager API
     rpc databases_get (ClusterDatabaseManager.Get.Req) returns (ClusterDatabaseManager.Get.Res);
     rpc databases_all (ClusterDatabaseManager.All.Req) returns (ClusterDatabaseManager.All.Res);
 }

--- a/cluster/cluster_service.proto
+++ b/cluster/cluster_service.proto
@@ -37,7 +37,7 @@ service TypeDBCluster {
     rpc users_all (ClusterUserManager.All.Req) returns (ClusterUserManager.All.Res);
 
     // User API
-    rpc users_delete (ClusterUser.Delete.Req) returns (ClusterUser.Delete.Res);
+    rpc user_delete (ClusterUser.Delete.Req) returns (ClusterUser.Delete.Res);
 
     // Database Manager API
     rpc databases_get (ClusterDatabaseManager.Get.Req) returns (ClusterDatabaseManager.Get.Res);

--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -18,20 +18,33 @@
 syntax = "proto3";
 
 option java_package = "com.vaticle.typedb.protocol";
-option java_outer_classname = "ClusterServiceProto";
-option java_generic_services = true;
-
-import "cluster/cluster_server.proto";
-import "cluster/cluster_user.proto";
-import "cluster/cluster_database.proto";
+option java_outer_classname = "ClusterUserProto";
 
 package typedb.protocol;
 
-service TypeDBCluster {
-    rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);
-    rpc users_contains (ClusterUserManager.Contains.Req) returns (ClusterUserManager.Contains.Res);
-    rpc users_create (ClusterUserManager.Create.Req) returns (ClusterUserManager.Create.Res);
-    rpc users_all (ClusterUserManager.All.Req) returns (ClusterUserManager.All.Res);
-    rpc databases_get (ClusterDatabaseManager.Get.Req) returns (ClusterDatabaseManager.Get.Res);
-    rpc databases_all (ClusterDatabaseManager.All.Req) returns (ClusterDatabaseManager.All.Res);
+message ClusterUserManager {
+
+    message Contains {
+        message Req {
+            string name = 1;
+        }
+        message Res {
+            bool contains = 1;
+        }
+    }
+
+    message Create {
+        message Req {
+            string name = 1;
+            string password = 2;
+        }
+        message Res {}
+    }
+
+    message All {
+        message Req {}
+        message Res {
+            repeated string names = 1;
+        }
+    }
 }

--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -48,3 +48,14 @@ message ClusterUserManager {
         }
     }
 }
+
+message ClusterUser {
+    message Delete {
+        message Req {
+            string name = 1;
+        }
+
+        message Res {}
+    }
+}
+

--- a/grpc/java/BUILD
+++ b/grpc/java/BUILD
@@ -28,6 +28,7 @@ java_grpc_compile(
     deps = [
         "//cluster:service-proto",
         "//cluster:server-proto",
+        "//cluster:user-proto",
         "//cluster:database-proto",
         "//common:answer-proto",
         "//common:concept-proto",

--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -42,6 +42,7 @@ ts_grpc_compile(
     name = "protocol-src",
     deps = [
         "//cluster:server-proto",
+        "//cluster:user-proto",
         "//cluster:database-proto",
         "//cluster:service-proto", # TODO: do we need this?
         "//common:answer-proto",

--- a/grpc/python/BUILD
+++ b/grpc/python/BUILD
@@ -26,6 +26,7 @@ python_grpc_compile(
     name = "protocol-src",
     deps = [
         "//cluster:server-proto",
+        "//cluster:user-proto",
         "//cluster:database-proto",
         "//cluster:service-proto",
         "//common:answer-proto",


### PR DESCRIPTION
## What is the goal of this PR?

We have added the user management protocol for TypeDB Cluster. It will allow TypeDB clients to perform user management operations such as adding and deleting a user.

## What are the changes implemented in this PR?

- Add `users_create`, `users_contains`, `users_all`, and `user_delete` endpoints in `TypeDBCluster` service.