### PR TITLE
Add transaction timeout to options

### DIFF
--- a/common/options.proto
+++ b/common/options.proto
@@ -47,10 +47,13 @@ message Options {
     oneof session_idle_timeout_opt {
         int32 session_idle_timeout_millis = 7;
     }
+    oneof transaction_timeout_opt {
+        int32 transaction_timeout_millis = 8;
+    }
     oneof schema_lock_acquire_timeout_opt {
-        int32 schema_lock_acquire_timeout_millis = 8;
+        int32 schema_lock_acquire_timeout_millis = 9;
     }
     oneof read_any_replica_opt {
-        bool read_any_replica = 9;
+        bool read_any_replica = 10;
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

To implement transaction timeouts (https://github.com/vaticle/typedb/issues/6487), we need to allow the user to configure the transaction timeout. This PR adds it to the protocol option to adjust the default transaction timeout.

## What are the changes implemented in this PR?

* Add `transaction_timeout_millis` to the options protocol object