### PR TITLE
Use token-based authentication for npm deployment

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -64,7 +64,7 @@ build:
         sudo apt update -y
         sudo apt install -y expect
         export DEPLOY_NPM_EMAIL=$REPO_VATICLE_EMAIL
-        export DEPLOY_NPM_TOKEN=$REPO_VATICLE_TOKEN
+        export DEPLOY_NPM_TOKEN=$REPO_VATICLE_NPM_TOKEN
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -63,9 +63,8 @@ build:
         wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
         sudo apt update -y
         sudo apt install -y expect
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
         export DEPLOY_NPM_EMAIL=$REPO_VATICLE_EMAIL
+        export DEPLOY_NPM_TOKEN=$REPO_VATICLE_TOKEN
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
     deploy-pip-snapshot:
@@ -112,9 +111,8 @@ release:
         wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
         sudo apt update -y
         sudo apt install -y expect
-        export DEPLOY_NPM_USERNAME=$REPO_NPM_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_NPM_PASSWORD
         export DEPLOY_NPM_EMAIL=$REPO_VATICLE_EMAIL
+        export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
         bazel run --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
       dependencies: [deploy-github]
     deploy-pip-release:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -63,7 +63,6 @@ build:
         wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
         sudo apt update -y
         sudo apt install -y expect
-        export DEPLOY_NPM_EMAIL=$REPO_VATICLE_EMAIL
         export DEPLOY_NPM_TOKEN=$REPO_VATICLE_NPM_TOKEN
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
       dependencies: [build, build-dependency]
@@ -111,7 +110,6 @@ release:
         wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
         sudo apt update -y
         sudo apt install -y expect
-        export DEPLOY_NPM_EMAIL=$REPO_VATICLE_EMAIL
         export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
         bazel run --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
       dependencies: [deploy-github]

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "084a9d839d8ec617b5fb3dca7a0c8614417586b8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/alexjpwalker/dependencies",
+        commit = "63f3eb8ac8966268f2310af5c7b41d74bd6f0751", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,6 +20,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/alexjpwalker/dependencies",
-        commit = "63f3eb8ac8966268f2310af5c7b41d74bd6f0751", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "5c899ccd7ecf2fb571c262c013881b54de1055cd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

The npm deployment infrastructure now uses token-based authentication instead of username/password authentication.

## What are the changes implemented in this PR?

See https://github.com/vaticle/bazel-distribution/pull/330 for an explanation of why this PR is necessary.

- Update dependencies (to make `deploy_npm` use token authentication) and automation.yml (to pass the token in)