### PR TITLE
Add missing CI dependency in deploy-pip-snapshot

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -80,6 +80,7 @@ build:
         export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/python:deploy-pip -- snapshot
+      dependencies: [build, build-dependency]
 
 release:
   filter:


### PR DESCRIPTION
## What is the goal of this PR?

`deploy-pip-snapshot` was incorrectly being run concurrently with `build` in CI. So we've now marked `build` as a dependency of `deploy-pip-snapshot`.

## What are the changes implemented in this PR?

Add missing CI dependency in deploy-pip-snapshot