### PR TITLE
Migrate to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -26,19 +26,19 @@ build:
       owner: vaticle
       branch: master
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       #NPM packages can't be built under RBE
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
@@ -47,7 +47,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [build, build-dependency]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
@@ -66,14 +66,9 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
-      command: |
-        pyenv install 3.7.12
-        pyenv global 3.7.12
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.12/lib/python3.7/site-packages/lsb_release.py
+      command: | 
         export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/python:deploy-pip -- snapshot
@@ -85,24 +80,21 @@ release:
     branch: master
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-21.04
-      command: |
-        pyenv install -s 3.7.12
-        pyenv global 3.7.12 system
-        pip3 install certifi
+      image: vaticle-ubuntu-22.04
+      command: | 
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-maven-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(cat VERSION) //grpc/java:deploy-maven -- release
       dependencies: [deploy-github]
     deploy-npm-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
         wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
@@ -112,13 +104,8 @@ release:
         bazel run --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
       dependencies: [deploy-github]
     deploy-pip-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
-        pyenv install 3.7.12
-        pyenv global 3.7.12
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.12/lib/python3.7/site-packages/lsb_release.py
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
         bazel run --define version=$(cat VERSION) //grpc/python:deploy-pip -- release

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "0e72bc924d188c4dbe13a33908971f23156ad001", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated our continuous integration for this repo to Vaticle Factory from Grabl.

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- uses of pyenv that are no longer in line with our approach.
- machine definitions from ubuntu 21.04 to 22.04.
- references to Grabl to Factory.
