### PR TITLE
Re-instate use of pyenv

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -66,7 +66,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       command: |
         export PYENV_ROOT="/opt/pyenv"

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -68,7 +68,13 @@ build:
         branch: master
       image: vaticle-ubuntu-20.04
       type: foreground
-      command: | 
+      command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.12
+        pyenv global 3.7.12
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.12/lib/python3.7/site-packages/lsb_release.py
         export DEPLOY_PIP_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/python:deploy-pip -- snapshot
@@ -81,7 +87,11 @@ release:
   deployment:
     deploy-github:
       image: vaticle-ubuntu-22.04
-      command: | 
+      command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install -s 3.7.12
+        pyenv global 3.7.12 system
+        python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
@@ -104,8 +114,14 @@ release:
         bazel run --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
       dependencies: [deploy-github]
     deploy-pip-release:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-22.04
       command: |
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.12
+        pyenv global 3.7.12
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.12/lib/python3.7/site-packages/lsb_release.py
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
         bazel run --define version=$(cat VERSION) //grpc/python:deploy-pip -- release

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -91,6 +91,9 @@ release:
         export PYENV_ROOT="/opt/pyenv"
         pyenv install -s 3.7.12
         pyenv global 3.7.12 system
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         python3 -m pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md


### PR DESCRIPTION
## What is the goal of this PR?

We've re-instated the use of pyenv in certain Factory job definitions. Removing it in favour of using the system python3 had far-reaching ramifications that proved too costly to immediately address.

## What are the changes implemented in this PR?

We've re-instated our use of pyenv in the `deploy-pip-*` family of jobs.