### PR TITLE
Use known working python version for GitHub deployment

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -89,8 +89,8 @@ release:
       image: vaticle-ubuntu-22.04
       command: |
         export PYENV_ROOT="/opt/pyenv"
-        pyenv install -s 3.7.12
-        pyenv global 3.7.12 system
+        pyenv install 3.7.9
+        pyenv global 3.7.9
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py


### PR DESCRIPTION
## What is the goal of this PR?

We've fixed the Python version learned from the successful GitHub deployment of typedb-common a definite working version of Python for this job.

## What are the changes implemented in this PR?

We've changed the used Python version to 3.7.9 from 3.7.12. This fixes a later bug where we attempt to link a library to a not-installed version of Python.