### PR TITLE
Fix crate snapshots failing to deploy due to bad version number

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "49de5861769ebb4b4b87438324e8a5922bf75dbe", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "8f21eb407287aee1d12e074b9d7960f935bf16f9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a bug where crate snapshots would fail to deploy, due to passing in an illegal version number.

## What are the changes implemented in this PR?

We've bumped `dependencies` to the latest version to get the fix in:
- https://github.com/vaticle/bazel-distribution/pull/362

It prepends `0.0.0-` to the version number we're deploying, if it looks like a commit SHA - i.e. when it is a snapshot deployment.

Without this fix, the version number we submit is a commit SHA, which, by itself, is not a valid crate version, and is rejected by repo.vaticle.com.