### PR TITLE
Fix Rust protocol failing to build in Cargo after an IDE sync

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -31,6 +31,7 @@ build:
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
+      machine: 4-core-8-gb
       image: vaticle-ubuntu-22.04
       #NPM packages can't be built under RBE
       command: |
@@ -38,6 +39,7 @@ build:
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
+      machine: 4-core-8-gb
       image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -31,6 +31,7 @@ build:
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
+      # TODO: use default machine once we delete the non-Rust protocols
       machine: 4-core-16-gb
       image: vaticle-ubuntu-22.04
       #NPM packages can't be built under RBE
@@ -39,6 +40,7 @@ build:
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
+      # TODO: use default machine once we delete the non-Rust protocols
       machine: 4-core-16-gb
       image: vaticle-ubuntu-22.04
       command: |

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -31,7 +31,7 @@ build:
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      machine: 4-core-8-gb
+      machine: 4-core-16-gb
       image: vaticle-ubuntu-22.04
       #NPM packages can't be built under RBE
       command: |
@@ -39,7 +39,7 @@ build:
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
-      machine: 4-core-8-gb
+      machine: 4-core-16-gb
       image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "ef99eda281717dafcb835cf924e4c673f46d7217", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "16b46048ef215bdd162b2d734a04ad9b6d1545e2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )


### PR DESCRIPTION
## What is the goal of this PR?

We fixed an issue where the Rust protocol would fail to build in Cargo after an IDE sync (by bumping `vaticle_dependencies`)

## What are the changes implemented in this PR?

The fix is in:
- https://github.com/vaticle/dependencies/pull/400

Summary: The `typedb-protocol` crate depends heavily on generated sources (a Rust gRPC + Proto library). The Rust IDE sync tool would generate these sources if run in the `typedb-protocol` repo itself, but not if run from a different repo that depended on Protocol. We fixed that.