### PR TITLE
Snake-case `is_root`, `is_abstract` in `Type`

### DIFF
--- a/common/concept.proto
+++ b/common/concept.proto
@@ -308,8 +308,8 @@ message Type {
     string scope = 2;
     Encoding encoding = 3;
     AttributeType.ValueType value_type = 4;
-    bool isRoot = 5;
-    bool isAbstract = 6;
+    bool is_root = 5;
+    bool is_abstract = 6;
 
     message Req {
         string label = 1;


### PR DESCRIPTION
## What is the goal of this PR?

`is_root` and `is_abstract` are now snake cased in `Type`.

## What are the changes implemented in this PR?

Protobuf convention is to use snake case. The casing affects the generated code. gRPC Java has been written with fallback logic to handle camelCase, but Python and Node.js do not.

Before this change, we generated the following TypeScript code:
```ts
export class Type extends jspb.Message { 
    getIsroot(): boolean;
    setIsroot(value: boolean): Type;
    getIsabstract(): boolean;
    setIsabstract(value: boolean): Type;
```
After the change, these become `getIsRoot`, `setIsAbstract`, etc.