### PR TITLE
Password policy and user management improvement

### DIFF
--- a/cluster/cluster_service.proto
+++ b/cluster/cluster_service.proto
@@ -40,6 +40,8 @@ service TypeDBCluster {
 
     // User API
     rpc user_password (ClusterUser.Password.Req) returns (ClusterUser.Password.Res);
+    rpc user_password_admin (ClusterUser.PasswordAdmin.Req) returns (ClusterUser.PasswordAdmin.Res);
+    rpc user_expiry_days (ClusterUser.ExpiryDays.Req) returns (ClusterUser.ExpiryDays.Res);
     rpc user_token (ClusterUser.Token.Req) returns (ClusterUser.Token.Res);
     rpc user_delete (ClusterUser.Delete.Req) returns (ClusterUser.Delete.Res);
 

--- a/cluster/cluster_service.proto
+++ b/cluster/cluster_service.proto
@@ -36,14 +36,14 @@ service TypeDBCluster {
     // User Manager API
     rpc users_contains (ClusterUserManager.Contains.Req) returns (ClusterUserManager.Contains.Res);
     rpc users_create (ClusterUserManager.Create.Req) returns (ClusterUserManager.Create.Res);
+    rpc users_delete (ClusterUserManager.Delete.Req) returns (ClusterUserManager.Delete.Res);
     rpc users_all (ClusterUserManager.All.Req) returns (ClusterUserManager.All.Res);
+    rpc users_password_set (ClusterUserManager.PasswordSet.Req) returns (ClusterUserManager.PasswordSet.Res);
+    rpc users_get (ClusterUserManager.Get.Req) returns (ClusterUserManager.Get.Res);
 
     // User API
-    rpc user_password (ClusterUser.Password.Req) returns (ClusterUser.Password.Res);
-    rpc user_password_admin (ClusterUser.PasswordAdmin.Req) returns (ClusterUser.PasswordAdmin.Res);
-    rpc user_expiry_days (ClusterUser.ExpiryDays.Req) returns (ClusterUser.ExpiryDays.Res);
+    rpc user_password_update (ClusterUser.PasswordUpdate.Req) returns (ClusterUser.PasswordUpdate.Res);
     rpc user_token (ClusterUser.Token.Req) returns (ClusterUser.Token.Res);
-    rpc user_delete (ClusterUser.Delete.Req) returns (ClusterUser.Delete.Res);
 
     // Database Manager API
     rpc databases_get (ClusterDatabaseManager.Get.Req) returns (ClusterDatabaseManager.Get.Res);

--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -51,10 +51,19 @@ message ClusterUserManager {
 
 message ClusterUser {
 
-    message Password {
+    message PasswordAdmin {
         message Req {
             string username = 1;
             string password = 2;
+        }
+        message Res {}
+    }
+
+    message Password {
+        message Req {
+            string username = 1;
+            string oldPassword = 2;
+            string newPassword = 3;
         }
         message Res {}
     }
@@ -66,6 +75,16 @@ message ClusterUser {
 
         message Res {
             string token = 1;
+        }
+    }
+
+    message ExpiryDays {
+        message Req {
+            string username = 1;
+        }
+
+        message Res {
+            int64 expiryDays = 1;
         }
     }
 

--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -78,8 +78,8 @@ message ClusterUser {
     message PasswordUpdate {
         message Req {
             string username = 1;
-            string oldPassword = 2;
-            string newPassword = 3;
+            string password_old = 2;
+            string password_new = 3;
         }
         message Res {}
     }
@@ -97,8 +97,8 @@ message ClusterUser {
 
 message User {
     string username = 1;
-    oneof password_expiry_opt {
-        int64 passwordExpiryDays = 2;
+    oneof password_expiry {
+        int64 password_expiry_days = 2;
     }
 }
 

--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -41,17 +41,21 @@ message ClusterUserManager {
         message Res {}
     }
 
+    message Delete {
+        message Req {
+            string username = 1;
+        }
+        message Res {}
+    }
+
     message All {
         message Req {}
         message Res {
-            repeated string names = 1;
+            repeated User users = 1;
         }
     }
-}
 
-message ClusterUser {
-
-    message PasswordAdmin {
+    message PasswordSet {
         message Req {
             string username = 1;
             string password = 2;
@@ -59,7 +63,19 @@ message ClusterUser {
         message Res {}
     }
 
-    message Password {
+    message Get {
+        message Req {
+            string username = 1;
+        }
+        message Res {
+            User user = 1;
+        }
+    }
+}
+
+message ClusterUser {
+
+    message PasswordUpdate {
         message Req {
             string username = 1;
             string oldPassword = 2;
@@ -77,22 +93,10 @@ message ClusterUser {
             string token = 1;
         }
     }
+}
 
-    message ExpiryDays {
-        message Req {
-            string username = 1;
-        }
-
-        message Res {
-            int64 expiryDays = 1;
-        }
-    }
-
-    message Delete {
-        message Req {
-            string username = 1;
-        }
-        message Res {}
-    }
+message User {
+    string username = 1;
+    int64 passwordExpiryDays = 2;
 }
 

--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -97,6 +97,8 @@ message ClusterUser {
 
 message User {
     string username = 1;
-    int64 passwordExpiryDays = 2;
+    oneof password_expiry_opt {
+        int64 passwordExpiryDays = 2;
+    }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

We've added two protobuf messages and modified one, enabling us to provide password policy features to TypeDB Cluster. See the PR for further information: https://github.com/vaticle/typedb-cluster/pull/456

## What are the changes implemented in this PR?

We've added:
* `users_password_set`, a message carrying the information for an administrator to overwrite any other user's existing password.
* `users_get`, that returns the user and associated information (currently only the username and the number of days before said user's password expires.)
* The `User` message, which includes all the information returned by `users_get` and `users_all`.

We've modified:
* `users_delete`, moving the method to the user manager.
* `user_password_update`, splitting it into `users_password_set` for administrators and this message that allows user's to update their own passwords.
