### PR TITLE
Define Password Expiry in terms of seconds

### DIFF
--- a/cluster/cluster_user.proto
+++ b/cluster/cluster_user.proto
@@ -98,7 +98,7 @@ message ClusterUser {
 message User {
     string username = 1;
     oneof password_expiry {
-        int64 password_expiry_days = 2;
+        int64 password_expiry_seconds = 2;
     }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

We've redefined the way we expose how long until a password expires in seconds, rather than days as was done previously.

## What are the changes implemented in this PR?

We've changed `password_expiry_days` to `password_expiry_seconds`.
