### PR TITLE
Introduce message types to encode annotations

### DIFF
--- a/common/concept.proto
+++ b/common/concept.proto
@@ -594,7 +594,7 @@ message ThingType {
             oneof filter {
                 AttributeType.ValueType value_type = 1;
             }
-            bool keys_only = 3;
+            repeated Type.Annotation annotations = 2;
         }
         message ResPart {
             repeated Type attribute_types = 1;
@@ -606,7 +606,7 @@ message ThingType {
             oneof filter {
                 AttributeType.ValueType value_type = 1;
             }
-            bool keys_only = 3;
+            repeated Type.Annotation annotations = 2;
         }
         message ResPart {
             repeated Type attribute_types = 1;

--- a/common/concept.proto
+++ b/common/concept.proto
@@ -206,9 +206,9 @@ message Thing {
 
     message GetHas {
         message Req {
-            // Only one filter can be set at a time (attribute_types or keys_only). repeated can't be used in a oneof
+            // Only one filter can be set at a time (attribute_types or annotations). repeated can't be used in a oneof
             repeated Type attribute_types = 1;
-            bool keys_only = 2;
+            repeated Annotation annotations = 2;
         }
         message ResPart {
             repeated Thing attributes = 1;
@@ -797,7 +797,7 @@ message AttributeType {
 
     message GetOwners {
         message Req {
-            bool only_key = 1;
+            repeated Annotation annotations = 1;
         }
         message ResPart {
             repeated Type thing_types = 1;
@@ -806,7 +806,7 @@ message AttributeType {
 
     message GetOwnersExplicit {
         message Req {
-            bool only_key = 1;
+            repeated Annotation annotations = 1;
         }
         message ResPart {
             repeated Type thing_types = 1;
@@ -850,3 +850,10 @@ message AttributeType {
     }
 }
 
+
+message Annotation {
+    oneof annotation {
+        bool key = 1;
+        bool unique = 2;
+    }
+}

--- a/common/concept.proto
+++ b/common/concept.proto
@@ -623,7 +623,7 @@ message ThingType {
             oneof overridden {
                 Type overridden_type = 2;
             }
-            bool is_key = 3;
+            repeated Annotation annotations = 3;
         }
         message Res {}
     }

--- a/common/concept.proto
+++ b/common/concept.proto
@@ -450,6 +450,13 @@ message Type {
         ROLE_TYPE = 4;
     }
 
+    message Annotation {
+        oneof annotation {
+            bool key = 1;
+            bool unique = 2;
+        }
+    }
+
     message Delete {
         message Req {}
         message Res {}
@@ -623,7 +630,7 @@ message ThingType {
             oneof overridden {
                 Type overridden_type = 2;
             }
-            repeated Annotation annotations = 3;
+            repeated Type.Annotation annotations = 3;
         }
         message Res {}
     }
@@ -797,7 +804,7 @@ message AttributeType {
 
     message GetOwners {
         message Req {
-            repeated Annotation annotations = 1;
+            repeated Type.Annotation annotations = 1;
         }
         message ResPart {
             repeated Type thing_types = 1;
@@ -806,7 +813,7 @@ message AttributeType {
 
     message GetOwnersExplicit {
         message Req {
-            repeated Annotation annotations = 1;
+            repeated Type.Annotation annotations = 1;
         }
         message ResPart {
             repeated Type thing_types = 1;
@@ -847,13 +854,5 @@ message AttributeType {
         message ResPart {
             repeated Thing attributes = 1;
         }
-    }
-}
-
-
-message Annotation {
-    oneof annotation {
-        bool key = 1;
-        bool unique = 2;
     }
 }

--- a/common/concept.proto
+++ b/common/concept.proto
@@ -208,7 +208,7 @@ message Thing {
         message Req {
             // Only one filter can be set at a time (attribute_types or annotations). repeated can't be used in a oneof
             repeated Type attribute_types = 1;
-            repeated Annotation annotations = 2;
+            repeated Type.Annotation annotations = 2;
         }
         message ResPart {
             repeated Thing attributes = 1;


### PR DESCRIPTION
## What is the goal of this PR?

We replace usages of `boolean` for key arguments with a message type called `Annotation` - this gives us a natural place to extend the set/capabilities of the annotations in the future. The new message type is used to implement the new "unique" annotation.

## What are the changes implemented in this PR?

Introduce `Type.Annotation`, which allows carrying either `Key` or `Unique` annotation. This message type is used through the Concept API protocol specification and replaces all usages of boolean `key` arguments.