### PR TITLE
Support TypeQL Fetch queries

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -84,6 +84,7 @@ proto_library(
         ":answer-proto",
         ":logic-proto",
         ":options-proto",
+        ":concept-proto",
     ],
 )
 

--- a/proto/answer.proto
+++ b/proto/answer.proto
@@ -49,15 +49,42 @@ message ConceptMapGroup {
     repeated ConceptMap concept_maps = 2;
 }
 
-message Numeric {
-    oneof value {
-        sint64 long_value = 1;
-        double double_value = 2;
-        bool nan = 3;
-    }
+message ValueGroup {
+    Concept owner = 1;
+    Value number = 2;
 }
 
-message NumericGroup {
-    Concept owner = 1;
-    Numeric number = 2;
+message ReadableConceptTree {
+
+    message Node {
+        oneof node {
+            Map map = 1;
+            List list = 2;
+            ReadableConcept leaf = 3;
+        }
+    }
+
+    message Map {
+        map<string, Node> map = 1;
+    }
+
+    message List {
+        repeated Node list = 1;
+    }
+
+    message ReadableConcept {
+        oneof readable_concept {
+            EntityType entity_type = 1;
+            RelationType relation_type = 2;
+            AttributeType attribute_type = 3;
+
+            RoleType role_type = 4;
+
+            Attribute attribute = 5;
+
+            Value value = 6;
+
+            ThingType.Root thing_type_root = 7;
+        }
+    }
 }

--- a/proto/answer.proto
+++ b/proto/answer.proto
@@ -62,7 +62,7 @@ message ReadableConceptTree {
         oneof node {
             Map map = 1;
             List list = 2;
-            ReadableConcept readableConcept = 3;
+            ReadableConcept readable_concept = 3;
         }
 
         message Map {

--- a/proto/answer.proto
+++ b/proto/answer.proto
@@ -51,40 +51,42 @@ message ConceptMapGroup {
 
 message ValueGroup {
     Concept owner = 1;
-    Value number = 2;
+    optional Value value = 2;
 }
 
 message ReadableConceptTree {
+
+    Node.Map root = 1;
 
     message Node {
         oneof node {
             Map map = 1;
             List list = 2;
-            ReadableConcept leaf = 3;
+            ReadableConcept readableConcept = 3;
         }
-    }
 
-    message Map {
-        map<string, Node> map = 1;
-    }
+        message Map {
+            map<string, Node> map = 1;
+        }
 
-    message List {
-        repeated Node list = 1;
-    }
+        message List {
+            repeated Node list = 1;
+        }
 
-    message ReadableConcept {
-        oneof readable_concept {
-            EntityType entity_type = 1;
-            RelationType relation_type = 2;
-            AttributeType attribute_type = 3;
+        message ReadableConcept {
+            oneof readable_concept {
+                EntityType entity_type = 1;
+                RelationType relation_type = 2;
+                AttributeType attribute_type = 3;
 
-            RoleType role_type = 4;
+                RoleType role_type = 4;
 
-            Attribute attribute = 5;
+                Attribute attribute = 5;
 
-            Value value = 6;
+                Value value = 6;
 
-            ThingType.Root thing_type_root = 7;
+                ThingType.Root thing_type_root = 7;
+            }
         }
     }
 }

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -23,7 +23,7 @@ option java_outer_classname = "QueryProto";
 import "proto/answer.proto";
 import "proto/logic.proto";
 import "proto/options.proto";
-import "concept.proto";
+import "proto/concept.proto";
 
 package typedb.protocol;
 
@@ -60,7 +60,7 @@ message QueryManager {
             Get.ResPart get_res_part = 100;
             GetGroup.ResPart get_group_res_part = 101;
             GetGroupAggregate.ResPart get_group_aggregate_res_part = 102;
-            Fetch.ResPart fech_res_part = 103;
+            Fetch.ResPart fetch_res_part = 103;
             Insert.ResPart insert_res_part = 104;
             Update.ResPart update_res_part = 105;
             Explain.ResPart explain_res_part = 106;

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -23,6 +23,7 @@ option java_outer_classname = "QueryProto";
 import "proto/answer.proto";
 import "proto/logic.proto";
 import "proto/options.proto";
+import "concept.proto";
 
 package typedb.protocol;
 
@@ -33,14 +34,15 @@ message QueryManager {
         oneof req {
             Define.Req define_req = 100;
             Undefine.Req undefine_req = 101;
-            Match.Req match_req = 102;
-            MatchAggregate.Req match_aggregate_req = 103;
-            MatchGroup.Req match_group_req = 104;
-            MatchGroupAggregate.Req match_group_aggregate_req = 105;
-            Insert.Req insert_req = 106;
-            Delete.Req delete_req = 107;
-            Update.Req update_req = 108;
-            Explain.Req explain_req = 109;
+            Get.Req get_req = 102;
+            GetAggregate.Req get_aggregate_req = 103;
+            GetGroup.Req get_group_req = 104;
+            GetGroupAggregate.Req get_group_aggregate_req = 105;
+            Fetch.Req fetch_req = 106;
+            Insert.Req insert_req = 107;
+            Delete.Req delete_req = 108;
+            Update.Req update_req = 109;
+            Explain.Req explain_req = 110;
         }
     }
 
@@ -48,23 +50,24 @@ message QueryManager {
         oneof res {
             Define.Res define_res = 100;
             Undefine.Res undefine_res = 101;
-            MatchAggregate.Res match_aggregate_res = 102;
+            GetAggregate.Res get_aggregate_res = 102;
             Delete.Res delete_res = 104;
         }
     }
 
     message ResPart {
         oneof res {
-            Match.ResPart match_res_part = 100;
-            MatchGroup.ResPart match_group_res_part = 101;
-            MatchGroupAggregate.ResPart match_group_aggregate_res_part = 102;
-            Insert.ResPart insert_res_part = 103;
-            Update.ResPart update_res_part = 104;
-            Explain.ResPart explain_res_part = 105;
+            Get.ResPart get_res_part = 100;
+            GetGroup.ResPart get_group_res_part = 101;
+            GetGroupAggregate.ResPart get_group_aggregate_res_part = 102;
+            Fetch.ResPart fech_res_part = 103;
+            Insert.ResPart insert_res_part = 104;
+            Update.ResPart update_res_part = 105;
+            Explain.ResPart explain_res_part = 106;
         }
     }
 
-    message Match {
+    message Get {
         message Req {
             string query = 1;
         }
@@ -73,17 +76,17 @@ message QueryManager {
         }
     }
 
-    message MatchAggregate {
+    message GetAggregate {
         message Req {
             string query = 1;
         }
 
         message Res {
-            Numeric answer = 1;
+            optional Value answer = 1;
         }
     }
 
-    message MatchGroup {
+    message GetGroup {
         message Req {
             string query = 1;
         }
@@ -93,13 +96,23 @@ message QueryManager {
         }
     }
 
-    message MatchGroupAggregate {
+    message GetGroupAggregate {
         message Req {
             string query = 1;
         }
 
         message ResPart {
-            repeated NumericGroup answers = 1;
+            repeated ValueGroup answers = 1;
+        }
+    }
+
+    message Fetch {
+        message Req {
+            string query = 1;
+        }
+
+        message ResPart {
+            repeated ReadableConceptTree answers = 1;
         }
     }
 

--- a/proto/version.proto
+++ b/proto/version.proto
@@ -24,7 +24,7 @@ option java_generic_services = true;
 package typedb.protocol;
 
 enum Version {
-  reserved 1; // add past version numbers into the reserved range
+  reserved 1, 2; // add past version numbers into the reserved range
   UNSPECIFIED = 0;
-  VERSION = 2;
+  VERSION = 3;
 }


### PR DESCRIPTION
## What is the goal of this PR?

We implement 'TypeQL Fetch' query protocols, plus refactor the existing protocols around 'Match' queries to use the new 'Get' query terminology. This is a major change to the protocol, so we update the protocol version to `3`.

## What are the changes implemented in this PR?

* Implement 'fetch' query API
* Implement 'fetch' response type: ReadableConceptTree
  * We don't expect to expose this type to the user, instead translating it to JSON
  * This type primarily lets use re-use message definitions for Concepts
* Refactor existing 'Match' query into 'Get' query terminology
* Update protocol VERSION to 3