### PR TITLE
Add driver fields to the connection open request

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "1200b4aef118e75ca070c4944e9459b2aab7982a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "371a67999d92b4d0833cd5e016ec01c6278e72c4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "d75f30de7902892b1d45015aefd20f06048b0458", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "1200b4aef118e75ca070c4944e9459b2aab7982a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -30,6 +30,8 @@ message Connection {
   message Open {
     message Req {
       Version version = 1;
+      string driver_language = 2;
+      string driver_version = 3;
     }
 
     message Res {}

--- a/proto/connection.proto
+++ b/proto/connection.proto
@@ -30,8 +30,8 @@ message Connection {
   message Open {
     message Req {
       Version version = 1;
-      string driver_language = 2;
-      string driver_version = 3;
+      optional string driver_name = 2;
+      optional string driver_version = 3;
     }
 
     message Res {}

--- a/proto/version.proto
+++ b/proto/version.proto
@@ -24,7 +24,7 @@ option java_generic_services = true;
 package typedb.protocol;
 
 enum Version {
-  reserved 1, 2; // add past version numbers into the reserved range
+  reserved 1 to 3; // add past version numbers into the reserved range
   UNSPECIFIED = 0;
-  VERSION = 3;
+  VERSION = 4;
 }


### PR DESCRIPTION
##  Usage and product changes

Added optional driver name and version fields to the Connection.Open request payload. 

Note: despite proto3 being able to handle added fields, due to a library packaging issue, older versions of TypeDB cannot handle new fields. This means that this change breaks backwards compatibility.