### PR TITLE
Migrate artifact hosting to cloudsmith

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -54,7 +54,7 @@ build:
       dependencies: [build, build-dependency]
       image: vaticle-ubuntu-22.04
       command: |
-        export DEPLOY_CRATE_TOKEN=$REPO_VATICLE_CRATES_TOKEN
+        export DEPLOY_CRATE_TOKEN=$REPO_TYPEDB_CRATES_TOKEN
         bazel run --define version=$(git rev-parse HEAD) //grpc/rust:deploy_crate -- snapshot
     deploy-npm-snapshot:
       filter:
@@ -63,8 +63,8 @@ build:
       dependencies: [build, build-dependency]
       image: vaticle-ubuntu-20.04
       command: |
-        export DEPLOY_NPM_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_NPM_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_NPM_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_NPM_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
 
 release:

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,7 +20,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "9632621e9e6381e192ba744ccb3f7447d0433c19", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,7 +20,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "41bb5bfb1b5f2adab4a88886d2e74f10d456e7e1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 

--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -96,8 +96,8 @@ assemble_npm(
 deploy_npm(
     name = "deploy-npm",
     target = ":assemble-npm",
-    snapshot = deployment["npm.snapshot"],
-    release = deployment["npm.release"],
+    snapshot = deployment["npm"]["snapshot"],
+    release = deployment["npm"]["release"],
 )
 
 checkstyle_test(

--- a/grpc/rust/BUILD
+++ b/grpc/rust/BUILD
@@ -71,8 +71,8 @@ assemble_crate(
 deploy_crate(
     name = "deploy_crate",
     target = ":assemble_crate",
-    snapshot = deployment["crate.snapshot"],
-    release = deployment["crate.release"]
+    snapshot = deployment["crate"]["snapshot"],
+    release = deployment["crate"]["release"]
 )
 
 checkstyle_test(


### PR DESCRIPTION
## Release notes: usage and product changes
Updates artifact deployment & consumption rules to use cloudsmith instead of the self-hosted sonatype repository.

## Implementation
* Bump `vaticle_dependencies` & update deployment targets