### PR TITLE
Update grpc dependency labels

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,8 +67,8 @@ crate_repositories()
 load("@vaticle_dependencies//tool/common:deps.bzl", "vaticle_dependencies_ci_pip", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
 vaticle_dependencies_ci_pip()
 
-# Load //builder/grpc
-load("@vaticle_dependencies//builder/grpc:deps.bzl", vaticle_grpc_deps = "deps")
+# Load //builder/proto_grpc
+load("@vaticle_dependencies//builder/proto_grpc:deps.bzl", vaticle_grpc_deps = "deps")
 vaticle_grpc_deps()
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,6 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "d75f30de7902892b1d45015aefd20f06048b0458", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "41bb5bfb1b5f2adab4a88886d2e74f10d456e7e1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
+

--- a/grpc/rust/BUILD
+++ b/grpc/rust/BUILD
@@ -19,7 +19,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 load("@vaticle_bazel_distribution//crates:rules.bzl", "assemble_crate", "deploy_crate")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@vaticle_dependencies//builder/grpc/rust:compile.bzl", "rust_tonic_compile")
+load("@vaticle_dependencies//builder/proto_grpc/rust:compile.bzl", "rust_tonic_compile")
 
 rust_tonic_compile(
     name = "typedb_protocol_src",


### PR DESCRIPTION
## Release notes: usage and product changes

We update all references to `@vaticle_dependencies//builder/grpc` to refer to `@vaticle_dependencies//builder/proto_grpc` instead. See https://github.com/vaticle/dependencies/pull/492.