### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -61,6 +61,19 @@ build:
         export DEPLOY_NPM_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_NPM_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //grpc/nodejs:deploy-npm -- snapshot
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+        - build-dependency
+        - deploy-crate-snapshot
+        - deploy-npm-snapshot
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
 release:
   filter:
@@ -101,3 +114,15 @@ release:
         sudo apt install -y expect
         export DEPLOY_NPM_TOKEN=$REPO_NPM_TOKEN
         bazel run --define version=$(cat VERSION) //grpc/nodejs:deploy-npm -- release
+    sync-dependencies-release:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - deploy-github
+        - deploy-crate-release
+        - deploy-npm-release
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@$(cat VERSION)


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.