### PR TITLE
Fix type script rules after updated dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,3 +7,7 @@ try-import ./.bazel-remote-cache.rc
 build --incompatible_strict_action_env --java_language_version=11 --javacopt='--release 11' --enable_runfiles
 run --incompatible_strict_action_env --java_runtime_version=remotejdk_11
 test --incompatible_strict_action_env --test_env=PATH --cache_test_results=no --java_runtime_version=remotejdk_11
+
+build --@aspect_rules_ts//ts:skipLibCheck=always
+fetch --@aspect_rules_ts//ts:skipLibCheck=always
+query --@aspect_rules_ts//ts:skipLibCheck=always

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,14 +138,6 @@ grpc_java_repositories()
 # Load NPM dependencies #
 #########################
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "04feedcd06f71d0497a81fdd3220140a373ff9d2bff94620fbd50b774f96d8e0",
-    strip_prefix = "bazel-lib-1.40.2",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz",
-)
-
 # Load //builder/nodejs
 load("@vaticle_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,6 +138,14 @@ grpc_java_repositories()
 # Load NPM dependencies #
 #########################
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "04feedcd06f71d0497a81fdd3220140a373ff9d2bff94620fbd50b774f96d8e0",
+    strip_prefix = "bazel-lib-1.40.2",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz",
+)
+
 # Load //builder/nodejs
 load("@vaticle_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -1,9 +1,9 @@
 @maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
 @maven//:com_electronwill_night_config_core_3_6_5
 @maven//:com_electronwill_night_config_toml_3_6_5
-@maven//:com_fasterxml_jackson_core_jackson_annotations_2_10_1
-@maven//:com_fasterxml_jackson_core_jackson_core_2_10_1
-@maven//:com_fasterxml_jackson_core_jackson_databind_2_10_1
+@maven//:com_fasterxml_jackson_core_jackson_annotations_2_16_1
+@maven//:com_fasterxml_jackson_core_jackson_core_2_16_1
+@maven//:com_fasterxml_jackson_core_jackson_databind_2_16_1
 @maven//:com_google_android_annotations_4_1_1_4
 @maven//:com_google_api_grpc_proto_google_common_protos_2_9_0
 @maven//:com_google_auth_google_auth_library_credentials_1_6_0
@@ -25,6 +25,7 @@
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
 @maven//:com_squareup_okhttp_okhttp_2_7_5
 @maven//:com_squareup_okio_okio_1_17_5
+@maven//:com_vdurmont_semver4j_3_1_0
 @maven//:commons_codec_commons_codec_1_13
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -1,9 +1,9 @@
 @maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
 @maven//:com_electronwill_night_config_core_3_6_5
 @maven//:com_electronwill_night_config_toml_3_6_5
-@maven//:com_fasterxml_jackson_core_jackson_annotations_2_16_1
-@maven//:com_fasterxml_jackson_core_jackson_core_2_16_1
-@maven//:com_fasterxml_jackson_core_jackson_databind_2_16_1
+@maven//:com_fasterxml_jackson_core_jackson_annotations_2_16_0
+@maven//:com_fasterxml_jackson_core_jackson_core_2_16_0
+@maven//:com_fasterxml_jackson_core_jackson_databind_2_16_0
 @maven//:com_google_android_annotations_4_1_1_4
 @maven//:com_google_api_grpc_proto_google_common_protos_2_9_0
 @maven//:com_google_auth_google_auth_library_credentials_1_6_0

--- a/grpc/nodejs/BUILD
+++ b/grpc/nodejs/BUILD
@@ -63,6 +63,7 @@ ts_project(
         ":node_modules/@types/node",
         ":node_modules/typescript",
     ],
+    transpiler = "tsc",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Release notes: usage and product changes
We update dependencies to fix `typedb-protocol` build.

## Implementation
We use the updated rules fixed in [dependencies](https://github.com/vaticle/dependencies/pull/547) and also update the code based on the new requirements of the updates `ts` rules.
We also update `maven` dependencies based on other `sync-dependencies` commits to fix the build.