### PR TITLE
Remove replica registration methods from the public proto

### DIFF
--- a/proto/server.proto
+++ b/proto/server.proto
@@ -20,21 +20,6 @@ message ServerManager {
             Server server = 1;
         }
     }
-
-    message Register {
-        message Req {
-          uint64 replica_id = 1;
-          string address = 2;
-        }
-        message Res {}
-    }
-
-    message Deregister {
-        message Req {
-            uint64 replica_id = 1;
-        }
-        message Res {}
-    }
 }
 
 message Server {

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -23,9 +23,8 @@ message ServerManager {
 }
 
 message Server {
-    optional string serving_address = 1;
-    optional string connection_address = 2;
-    optional ReplicaStatus replica_status = 3;
+    optional string address = 1;
+    optional ReplicaStatus replica_status = 2;
 
     message ReplicaStatus {
         uint64 replica_id = 1;

--- a/proto/typedb_service.proto
+++ b/proto/typedb_service.proto
@@ -25,8 +25,6 @@ service TypeDB {
     // Server Manager API
     rpc servers_all (ServerManager.All.Req) returns (ServerManager.All.Res);
     rpc servers_get (ServerManager.Get.Req) returns (ServerManager.Get.Res);
-    rpc servers_register(ServerManager.Register.Req) returns (ServerManager.Register.Res);
-    rpc servers_deregister(ServerManager.Deregister.Req) returns (ServerManager.Deregister.Res);
 
     // Server API
     rpc server_version (Server.Version.Req) returns (Server.Version.Res);


### PR DESCRIPTION
## Release notes: usage and product changes
Remove replica registration/deregistration methods from the public protocol as a part of the move to the admin tool. These functions will be available only for the system administrators with access to the server's localhost.

Additionally, remove the unnecessary address fields from `Server` messages.

## Implementation
