### PR TITLE
Upgrade Rust toolchain and update dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,14 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 
 # Rust
 bazel_dep(name = "rules_rust", version = "0.56.0")
+# Backport a bug fix from rules_rust 0.58 (bazelbuild/rules_rust#3251)
+git_override(
+    module_name = "rules_rust",
+    remote = "https://github.com/bazelbuild/rules_rust",
+    tag = "0.56.0",
+    patches = ["@@typedb_dependencies+//patches:rules_rust.patch"],
+)
+
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,6 +29,9 @@ rust.toolchain(
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
 
+rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
+rust_host_tools.host_tools(version = "1.93.0")
+
 # Node.js / TypeScript
 bazel_dep(name = "rules_nodejs", version = "6.3.2")
 bazel_dep(name = "aspect_rules_js", version = "2.1.2")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,8 +23,8 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_rust", version = "0.56.0")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
-    edition = "2021",
-    versions = ["1.81.0"],
+    edition = "2024",
+    versions = ["1.93.0"],
 )
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
@@ -105,7 +105,7 @@ bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/dependencies",
-    commit = "a798dc0869d494bf0c7b033ee226df2efbef2830",
+    commit = "4b4a8c694ab098a52678d66608ce0a9fb13b7cff",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -116,7 +116,7 @@ bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
     remote = "https://github.com/typedb/dependencies",
-    commit = "4b4a8c694ab098a52678d66608ce0a9fb13b7cff",
+    commit = "32a7fde17ad17b775a8ccc0867c87f119749e7ea",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -8238,7 +8238,7 @@
     },
     "@@typedb_dependencies+//library/maven:maven_extension.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "/1GgGaqvvh9dMGzSw9vP/DjY2L59wajADIxosbWZaDs=",
+        "bzlTransitiveDigest": "xMWpLSMTFb8Mnv/A2T5iiIIV6+62B5LCSeaPDQfgIik=",
         "usagesDigest": "DN99BxtZyqFjtkyBux+PqWhuuOm4BMqdgkkIC2I19Hw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -8506,7 +8506,25 @@
                 "{ \"group\": \"org.zeroturnaround\", \"artifact\": \"zt-exec\", \"version\": \"1.10\" }",
                 "{ \"group\": \"com.mailgun\", \"artifact\": \"mailgun-java\", \"version\": \"1.1.2\" }",
                 "{ \"group\": \"io.github.openfeign\", \"artifact\": \"feign-core\", \"version\": \"13.2.1\" }",
-                "{ \"group\": \"com.vdurmont\", \"artifact\": \"semver4j\", \"version\": \"3.1.0\" }"
+                "{ \"group\": \"com.vdurmont\", \"artifact\": \"semver4j\", \"version\": \"3.1.0\" }",
+                "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-runner\", \"version\": \"2.28.3\" }",
+                "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-cloud-runner\", \"version\": \"2.28.3\" }",
+                "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-common\", \"version\": \"0.0.0-56ed57603e67103d0a371721db2d15e7e727ccac\" }",
+                "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-driver\", \"version\": \"2.28.0-rc0\" }",
+                "{ \"group\": \"com.vaticle.typeql\", \"artifact\": \"typeql-lang\", \"version\": \"2.28.0\" }",
+                "{ \"group\": \"aws.sdk.kotlin\", \"artifact\": \"ebs-jvm\", \"version\": \"1.3.23\" }",
+                "{ \"group\": \"aws.sdk.kotlin\", \"artifact\": \"ec2-jvm\", \"version\": \"1.3.23\" }",
+                "{ \"group\": \"co.novu\", \"artifact\": \"novu-kotlin\", \"version\": \"1.1.0\" }",
+                "{ \"group\": \"com.google.apis\", \"artifact\": \"google-api-services-servicecontrol\", \"version\": \"v1-rev20250124-2.0.0\" }",
+                "{ \"group\": \"com.google.cloud\", \"artifact\": \"google-cloud-compute\", \"version\": \"1.55.0\" }",
+                "{ \"group\": \"com.knuddels\", \"artifact\": \"jtokkit\", \"version\": \"1.1.0\" }",
+                "{ \"group\": \"com.openai\", \"artifact\": \"openai-java\", \"version\": \"0.36.0\" }",
+                "{ \"group\": \"com.openai\", \"artifact\": \"openai-java-client-okhttp\", \"version\": \"0.36.0\" }",
+                "{ \"group\": \"com.openai\", \"artifact\": \"openai-java-core\", \"version\": \"0.36.0\" }",
+                "{ \"group\": \"io.fabric8\", \"artifact\": \"volumesnapshot-client\", \"version\": \"6.10.0\" }",
+                "{ \"group\": \"io.fabric8\", \"artifact\": \"volumesnapshot-model\", \"version\": \"6.10.0\" }",
+                "{ \"group\": \"io.ktor\", \"artifact\": \"ktor-server-cors-jvm\", \"version\": \"2.3.7\" }",
+                "{ \"group\": \"io.ktor\", \"artifact\": \"ktor-server-status-pages-jvm\", \"version\": \"2.3.7\" }"
               ],
               "excluded_artifacts": [
                 "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-ffi\" }",

--- a/grpc/rust/Cargo.toml
+++ b/grpc/rust/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "typedb-protocol"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
## Release notes: usage and product changes

We update Rust toolchain to 1.93.0, as well as dependencies.

## Implementation
